### PR TITLE
Don't crash if the events file has no events

### DIFF
--- a/lib/bbbevents/recording.rb
+++ b/lib/bbbevents/recording.rb
@@ -25,6 +25,7 @@ module BBBEvents
 
       recording_data = raw_recording_data["recording"]
       events = recording_data["event"]
+      events = [] if events.nil?
       events = [events] unless events.is_a?(Array)
 
       @metadata   = recording_data["metadata"]
@@ -33,12 +34,15 @@ module BBBEvents
       internal_meeting_id = recording_data["meeting"]["id"]
 
       @timestamp  = extract_timestamp(internal_meeting_id)
+      @start = Time.at(@timestamp / 1000)
 
-      @first_event = events.first["timestamp"].to_i
-      @last_event  = events.last["timestamp"].to_i
-
-      @start    = Time.at(@timestamp / 1000)
-      @finish   = Time.at(timestamp_conversion(@last_event))
+      if events.length > 0
+        @first_event = events.first["timestamp"].to_i
+        @last_event  = events.last["timestamp"].to_i
+        @finish = Time.at(timestamp_conversion(@last_event))
+      else
+        @finish = @start
+      end
       @duration = (@finish - @start).to_i
 
       @attendees = {}

--- a/spec/bbbevents_spec.rb
+++ b/spec/bbbevents_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe BBBEvents do
       expect { BBBEvents.parse(file_fixture("no_key.xml")) }.to raise_error("no_key.xml is missing recording key.")
     end
 
+    it "should return BBBEvents::Recording when valid xml content but no events." do
+      sample_no_events = BBBEvents.parse(file_fixture("sample_no_events.xml"))
+      expect(sample_no_events).to be_an_instance_of(BBBEvents::Recording)
+    end
+
     it "should return BBBEvents::Recording." do
       expect(@sample).to be_an_instance_of(BBBEvents::Recording)
     end

--- a/spec/fixtures/files/sample_no_events.xml
+++ b/spec/fixtures/files/sample_no_events.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<recording meeting_id="3107946ecc201837635e07aeb86d785e9fe46507-1534433961829" bbb_version="2.0.0">
+  <meeting id="3107946ecc201837635e07aeb86d785e9fe46507-1534433961829" externalId="ae5e285551844c61c757f4c8f233850a2e0b16bf" name="Home Room" breakout="false"/>
+  <metadata gl-listed="false" isBreakout="false" meetingId="ae5e285551844c61c757f4c8f233850a2e0b16bf" meetingName="Home Room"/>
+</recording>


### PR DESCRIPTION
There's a few cases where when something goes wrong on the BBB server,
we can get an events file which has no recording events in it.

I've changed the places in bbbevents where it assumes there must be at
least one event present to have a fallback when there are no events. You
won't get any useful statistics, but at least it won't crash.