### PR TITLE
Relax dependency on activesupport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.2
+  RUBY_VERSION: '2.7'
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
 name: CI
@@ -8,30 +8,17 @@ on: [push, pull_request]
 jobs:
   test:
     name: Rake Test
+    strategy:
+      matrix:
+        ruby: ['2.5', '2.7', '3.0']
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Install Ruby ${{ env.RUBY_VERSION }}
-        uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
-      - name: Bundle cache
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: Run Rake Test
-        run:  |
-          bundler exec rake
+      - run: bundler exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,23 +2,25 @@ PATH
   remote: .
   specs:
     bbbevents (1.2.0)
-      activesupport (>= 5.0.0.1, < 6.1)
+      activesupport (>= 5.0.0.1, < 7)
+      rexml
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.3)
-    i18n (1.8.2)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
+    minitest (5.14.4)
     rake (13.0.1)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -32,16 +34,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bbbevents!
-  bundler (~> 1.15)
+  bundler (~> 2.0)
   rake (~> 13.0)
   rspec (~> 3.4)
+
+BUNDLED WITH
+   2.1.4

--- a/bbbevents.gemspec
+++ b/bbbevents.gemspec
@@ -21,11 +21,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"
 
   # Gem dependecies.
   spec.add_dependency 'activesupport', '>= 5.0.0.1', '< 7'
+  spec.add_dependency 'rexml' # Required for activesupport from_xml
 
 end

--- a/bbbevents.gemspec
+++ b/bbbevents.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
 
   # Gem dependecies.
-  spec.add_dependency 'activesupport', '>= 5.0.0.1', '< 6.1'
+  spec.add_dependency 'activesupport', '>= 5.0.0.1', '< 7'
 
 end


### PR DESCRIPTION
Allow all versions < 7 so that the gem can be used with newer rails 6
point releases.