### PR TITLE
Fix ActiveSupport include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Rake Test
     strategy:
       matrix:
-        ruby: ['2.5', '2.7', '3.0']
+        ruby: ['2.7', '3.0']
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,3 @@
-env:
-  RUBY_VERSION: '2.7'
-  DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-
 name: CI
 on: [push, pull_request]
 
@@ -14,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/lib/bbbevents/recording.rb
+++ b/lib/bbbevents/recording.rb
@@ -1,5 +1,6 @@
 require 'csv'
 require 'json'
+require 'active_support'
 require 'active_support/core_ext/hash'
 
 module BBBEvents


### PR DESCRIPTION
Following the instructions in
https://guides.rubyonrails.org/active_support_core_extensions.html using ActiveSupport in a stand-alone way requires first including 'active_support' and then including specific modules afterwards.

This fixes compatibility with ActiveSupport 7.