### PR TITLE
Release workflow: Run on any tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: bbbevents gem release
 on:
   push:
     tags:
-      - v*
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
The existing tags for release versions don't have a v prefix. For consistency, we'd like to keep doing the same thing.

Run the release workflow on all tags. We'll just have to make sure not to use tags for things other than releases.