### PR TITLE
fix timestamp format for attendee joins and poll start times

### DIFF
--- a/lib/bbbevents/attendee.rb
+++ b/lib/bbbevents/attendee.rb
@@ -88,9 +88,9 @@ module BBBEvents
         duration: @duration,
         recent_talking_time: @recent_talking_time > 0 ? BBBEvents.format_datetime(Time.at(@recent_talking_time)) : '',
         engagement: @engagement,
-        sessions: @sessions.map { |session| {
+        sessions: @sessions.map { |key, session| {
             joins: session[:joins].map { |join| join.merge({ timestamp: BBBEvents.format_datetime(join[:timestamp])}) },
-            leaves: session[:leaves].map { |leave| leave.merge({ timestamp: BBBEvents.format_datetime(leave[:timestamp])}) }
+            lefts: session[:lefts].map { |leave| leave.merge({ timestamp: BBBEvents.format_datetime(leave[:timestamp])}) }
           }
         }
       }

--- a/lib/bbbevents/poll.rb
+++ b/lib/bbbevents/poll.rb
@@ -23,5 +23,15 @@ module BBBEvents
     def to_json
       JSON.generate(as_json)
     end
+
+    def as_json
+      {
+        id: @id,
+        published: @published,
+        options: @options,
+        start: BBBEvents.format_datetime(@start),
+        votes: @votes
+      }
+    end
   end
 end

--- a/spec/attendee_spec.rb
+++ b/spec/attendee_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe BBBEvents::Attendee do
       expect(@attendee).to respond_to(:moderator?)
     end
   end
+
+  context "#joins?" do
+    it "has joins as array." do
+      expect(@attendee.joins).to be_a(Array)
+      expect(@attendee.as_json[:joins][0]).to eql('2018-08-16T15:39:21.000+00:00')
+    end
+  end
+
+  context "session#joins?" do
+    it "has session joins as array." do
+      expect(@attendee.as_json[:sessions][0][:joins][0][:timestamp]).to eql('2018-08-16T15:39:21.000+00:00')
+    end
+  end
 end

--- a/spec/poll_2_6_spec.rb
+++ b/spec/poll_2_6_spec.rb
@@ -31,4 +31,11 @@ RSpec.describe BBBEvents::Poll do
       expect(@poll).to respond_to(:published?)
     end
   end
+
+  context "#poll json timestamp format" do
+    it "has fixed poll json timestamp format." do
+      puts @poll.as_json[:start]
+      expect(@poll.as_json[:start]).to eq('2023-05-17T18:59:56.000+00:00')
+    end
+  end
 end


### PR DESCRIPTION
The attendee joins was failing due to the wrong object structure while traversing the hash.

Also, the  poll start times were not formatted when printing as JSON.