### PR TITLE
 - fix engagement to handle the new in the event format

### DIFF
--- a/lib/bbbevents/events.rb
+++ b/lib/bbbevents/events.rb
@@ -102,7 +102,7 @@ module BBBEvents
         if status == RAISEHAND && status_value == 'true'
           # Count only raise hand event and not lower hand
           attendee.engagement[:raisehand] += 1
-        elsif status == 'reactionEmoji'
+        elsif status == 'reactionEmoji' && status_value != 'none'
           attendee.engagement[:emojis] += 1
 
         # Support old event format

--- a/lib/bbbevents/events.rb
+++ b/lib/bbbevents/events.rb
@@ -94,12 +94,21 @@ module BBBEvents
       intUserId = e['userId']
 
       return unless attendee = @attendees[@externalUserId[intUserId]]
-      status = e["value"]
+      status = e["status"]
+      status_value = e['value']
 
       if attendee
-        if status == RAISEHAND
+        # Support new event format
+        if status == RAISEHAND && status_value == 'true'
+          # Count only raise hand event and not lower hand
           attendee.engagement[:raisehand] += 1
-        elsif EMOJI_WHITELIST.include?(status)
+        elsif status == 'reactionEmoji'
+          attendee.engagement[:emojis] += 1
+
+        # Support old event format
+        elsif  status_value == RAISEHAND
+          attendee.engagement[:raisehand] += 1
+        elsif EMOJI_WHITELIST.include?(status_value)
           attendee.engagement[:emojis] += 1
         end
       end


### PR DESCRIPTION
The new format is now

```
  <event timestamp="31361740049" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-27T14:36:51.984Z</date>
    <status>raiseHand</status>
    <userId>w_m3hbbgsszgzf</userId>
    <value>true</value>
    <timestampUTC>1709044611984</timestampUTC>
  </event>
  <event timestamp="31361742196" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-27T14:36:54.132Z</date>
    <status>reactionEmoji</status>
    <userId>w_m3hbbgsszgzf</userId>
    <value>👏</value>
    <timestampUTC>1709044614132</timestampUTC>
```

while the old format is

```
  <event timestamp="19632690" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2023-05-01T15:58:09.838Z</date>
    <status>emojiStatus</status>
    <userId>w_cvigtg2clump</userId>
    <value>raiseHand</value>
    <timestampUTC>1682956689838</timestampUTC>
  </event>
```
