### PR TITLE
include `csv` as dependency

### DIFF
--- a/bbbevents.gemspec
+++ b/bbbevents.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   # Gem dependecies.
   spec.add_dependency 'activesupport', '>= 5.0.0.1', '< 8'
   spec.add_dependency 'rexml' # Required for activesupport from_xml
-
+  spec.add_dependency 'csv'
 end


### PR DESCRIPTION
Fix:

```
/Users/mabras/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bbbevents-2.0.0/lib/bbbevents/recording.rb:1: warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
```

in Ruby 3.3.5